### PR TITLE
CSS bug on reload fix

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,10 +5,9 @@ import Content from '../components'
 import Preloader from '../components/Preloader'
 
 export default function Index() {
-    const [loading, setLoading] = useState(false)
+    const [loading, setLoading] = useState(true)
 
     useEffect(() => {
-        setLoading(true)
         setTimeout(() => {
             setLoading(false)
         }, 3000)


### PR DESCRIPTION
### Summary

Fixed the css bug that appeard during reload of the page by making the gif appear first at reload

#### Demo
![preload-fix](https://user-images.githubusercontent.com/25298468/130314422-60c3716d-0cf2-4e1d-8d27-359081b6b877.gif)


### Browser checklist

This PR has been tested in the following browsers:

-   [x] Chrome
-   [ ] Safari
-   [x] Firefox

### Closes #18 
